### PR TITLE
Lock version of pry-byebug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,7 +79,7 @@ group :development do
   # PRY utilities
   gem "pry-rails"
   gem "pry-doc"
-  gem "pry-byebug"
+  gem 'pry-byebug', '1.3.3'
   gem "pry-stack_explorer"
   gem "pry-remote"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,8 +70,9 @@ GEM
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     builder (3.2.2)
-    byebug (4.0.5)
-      columnize (= 0.9.0)
+    byebug (2.7.0)
+      columnize (~> 0.3)
+      debugger-linecache (~> 1.2)
     capybara (2.4.4)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -101,6 +102,7 @@ GEM
     columnize (0.9.0)
     commonjs (0.2.7)
     debug_inspector (0.0.2)
+    debugger-linecache (1.2.0)
     devise (3.5.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -255,8 +257,8 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    pry-byebug (3.1.0)
-      byebug (~> 4.0)
+    pry-byebug (1.3.3)
+      byebug (~> 2.7)
       pry (~> 0.10)
     pry-doc (0.8.0)
       pry (~> 0.9)
@@ -473,7 +475,7 @@ DEPENDENCIES
   paperclip
   parallel_tests
   poltergeist
-  pry-byebug
+  pry-byebug (= 1.3.3)
   pry-doc
   pry-rails
   pry-remote


### PR DESCRIPTION
# WHAT
I locked version of pry-byebug

# WHY
Because previous version had problem of dependency with pry-remote and pry-byebug.